### PR TITLE
Refresh the sensor cache when the cache vessel is changed

### DIFF
--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -1539,11 +1539,17 @@ namespace Telemachus
 
         #region Fields
 
+        protected event EventHandler<EventArgs> VesselPropertyChanged;
+
         private Vessel theVessel = null;
         public Vessel vessel
         {
             get { return theVessel; }
-            set { theVessel = value; }
+            set {
+                if (theVessel == value) return;
+                theVessel = value;
+                if (VesselPropertyChanged != null) VesselPropertyChanged(this, EventArgs.Empty);
+            }
         }
 
         protected Dictionary<string, List<T>> partModules = new Dictionary<string, List<T>>();
@@ -1701,6 +1707,7 @@ namespace Telemachus
         public SensorCache(VesselChangeDetector vesselChangeDetector)
         {
             vesselChangeDetector.UpdateNotify += update;
+            VesselPropertyChanged += update;
         }
 
         private void update(object sender, EventArgs eventArgs)


### PR DESCRIPTION
Fixes bug whereby the first time sensors are called on, returns a value saying there are no sensors.

This is because SensorCache has a `null` vessel until assigned during the "s.*" API evaluation, but the vessel was only scanned in every `TelemachusBehaviour::Update`.

Hurrah for spending hours chasing bugs in my code only to find it isn't what I've changed :satisfied:!